### PR TITLE
Doc updates

### DIFF
--- a/docs/usage/configuration/config-reference.md
+++ b/docs/usage/configuration/config-reference.md
@@ -15,7 +15,7 @@ These are all the configuration options supported by ValiPop. Options suffixed w
     - [`results_save_location`](#results_save_location)
     - [`summary_results_save_location`](#summary_results_save_location)
     - [`var_data_files`*](#var_data_files)
-    - [`project_location`*](#project_location)
+    - [`project_location`](#project_location)
 - [Dates and Periods](#dates-and-periods)
     - [`tS`*](#tS)
     - [`t0`*](#t0)

--- a/docs/usage/guides/docker.md
+++ b/docs/usage/guides/docker.md
@@ -26,7 +26,7 @@ You can install the latest valiPop image by running the following command
 ```sh
 # In a terminal (Windows/MacOs/Linux)
 
-docker pull ghcr.io/stacs-srg/valipop:master
+docker pull ghcr.io/stacs-srg/valipop:main
 ```
 
 To verify you have installed the image correctly, you can run the following command
@@ -34,7 +34,7 @@ To verify you have installed the image correctly, you can run the following comm
 ```shell
 # In a terminal (Windows/MacOs/Linux)
 
-docker run ghcr.io/stacs-srg/valipop:master
+docker run ghcr.io/stacs-srg/valipop:main
 ```
 
 which should print the following message
@@ -68,15 +68,16 @@ In our case, we will want to link the following directories to the container:
   - To access the config file and input distributions
 - `./results` to `/app/results`
   - To receive the results
+  - Note `./results` must be created prior to execution
 
 Therefore we can run the container with the following command to bind the directories
 
 ```sh
 # For Windows
-docker run -v .\src:/app/src -v .\results:/app/results ghcr.io/stacs-srg/valipop:master /app/src/main/resources/valipop/config/scot/config.txt
+docker run -v .\src:/app/src -v .\results:/app/results ghcr.io/stacs-srg/valipop:main /app/src/main/resources/valipop/config/scot/config.txt
 
 # For MacOs/Linux
-docker run -v ./src:/app/src -v ./results:/app/results ghcr.io/stacs-srg/valipop:master /app/src/main/resources/valipop/config/scot/config.txt
+docker run -v ./src:/app/src -v ./results:/app/results ghcr.io/stacs-srg/valipop:main /app/src/main/resources/valipop/config/scot/config.txt
 ```
 By default, this will run ValiPop will a starting population size of 1000 between the years 1855 to 1973. This will usually take under 5 minutes to run, and should eventually print something like the following:
 
@@ -97,7 +98,7 @@ In value[[3L]](cond) : Population size too small for partnering analysis
 Validation score: 0.0 (good)
 ```
 
-In the same directory as the ValiPop directory, there should also now exist a `results/` directory with the generated population records. This specific run should be located in a directory like
+The generated population records will now exist in the specified results directory. This specific run should be located in a directory like:
 
 ```
 results/example/2025-03-24T10-50-39-702/
@@ -140,9 +141,11 @@ You can make the following changes to the configuration file to alter ValiPop's 
 You may then save the changes and rerun the following command for different results.
 
 ```sh
-# In a terminal (Windows/MacOs/Linux)
+# For Windows
+docker run -v .\src:/app/src -v .\results:/app/results ghcr.io/stacs-srg/valipop:main /app/src/main/resources/valipop/config/scot/config.txt
 
-java -jar valipop.jar src/main/resources/valipop/config/scot/config.txt
+# For MacOs/Linux
+docker run -v ./src:/app/src -v ./results:/app/results ghcr.io/stacs-srg/valipop:main /app/src/main/resources/valipop/config/scot/config.txt
 ```
 
 [Read more about the configuration options.](../configuration/config-reference.md)

--- a/docs/usage/guides/java.md
+++ b/docs/usage/guides/java.md
@@ -29,9 +29,25 @@ R -e "install.packages('geepack', repos = c(CRAN = 'https://cloud.r-project.org'
 
 To run ValiPop with Java, you only need the ValiPop JAR file. However we will be running ValiPop with some sample configuration which needs to be installed separately.
 
-### 2.1. Installing the JAR file
+### 2.1. Installing the configuration
+
+We will use the config and input files from the [ValiPop repository](https://github.com/stacs-srg/population-model). To install the repository, run the following command
+
+```shell
+# In a terminal (Windows/macOS/Linux)
+
+git clone https://github.com/stacs-srg/population-model.git
+```
+
+Within the repository, we will use the following config file
+
+`src/main/resources/valipop/config/scot/config.txt`
+
+### 2.2. Installing the JAR file
 
 You can install the latest ValiPop JAR file from [the releases page](https://github.com/stacs-srg/population-model/releases).
+
+For the following steps, the JAR file should be installed in the root of the ValiPop repository.
 
 To verify that the JAR file is working, navigate to the directory it is in and run the following command
 
@@ -47,20 +63,6 @@ which should print the following message
 No config file given as 1st arg
 Incorrect arguments given
 ```
-
-### 2.2. Installing the configuration
-
-We will use the config and input files from the [ValiPop repository](https://github.com/stacs-srg/population-model). To install the repository in the same directory as the valiPop JAR file, run the following command
-
-```shell
-# In a terminal (Windows/macOS/Linux)
-
-git clone https://github.com/stacs-srg/population-model.git
-```
-
-Within the repository, we will use the following config file
-
-`src/main/resources/valipop/config/scot/config.txt`
 
 ### 3. Execution
 


### PR DESCRIPTION
Contains a number of fixes/revisions to the documentation contained in docs/usage:
- docs/usage/guides/java.md
    - Revised unclear instructions of directory to install Java file into.
- docs/usage/guides/docker.md
    - Replaced outdated references to "valipop:master" with "valipop:main"
    - Added note that "results" directory must be manually created and removed misleading reference to results directory being automatically generated (as this doesn't apply to the externally linked directory).
    - Corrected incorrect code-block which contained java usage instructions.
- docs/usage/configuration/config-reference.md
    - Unmarked 'project_location' as required. 