### PR TITLE
Add workflow security-events permissions

### DIFF
--- a/.github/workflows/push-jobs.yml
+++ b/.github/workflows/push-jobs.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      security-events: write
     steps:
       - name: Check out project
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
Adds security-events: write permission in build-and-test workflow to fix issues with composite actions workflows when merging from forks.